### PR TITLE
feat: add chance and water-avoidance options for random block generation

### DIFF
--- a/src/main/java/me/i2000c/newalb/listeners/ChunkEvent.java
+++ b/src/main/java/me/i2000c/newalb/listeners/ChunkEvent.java
@@ -22,6 +22,7 @@ public class ChunkEvent implements Listener{
                     int z = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.radz");
                     int blocks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.blocks");
                     boolean floating_blocks = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.floating-blocks");
+                    boolean avoid_near_water = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.avoid-near-water");
                     boolean send_finish_message = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.send-finish-message");
 
                     int maxTasks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.maxTasks");
@@ -32,7 +33,7 @@ public class ChunkEvent implements Listener{
                         }
                         Block b = e.getChunk().getBlock(8, 64, 8);
 
-                        RandomBlocks rb = new RandomBlocks(x, y, z, blocks, floating_blocks, b.getLocation(), send_finish_message);
+                        RandomBlocks rb = new RandomBlocks(x, y, z, blocks, floating_blocks, avoid_near_water, b.getLocation(), send_finish_message);
                         rb.generatePackets();
                     }
                 }

--- a/src/main/java/me/i2000c/newalb/listeners/ChunkEvent.java
+++ b/src/main/java/me/i2000c/newalb/listeners/ChunkEvent.java
@@ -22,7 +22,7 @@ public class ChunkEvent implements Listener{
                     int z = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.radz");
                     int blocks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.blocks");
                     boolean floating_blocks = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.floating-blocks");
-                    boolean avoid_near_water = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.avoid-near-water");
+                    boolean avoid_water = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.avoid-water");
                     boolean send_finish_message = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.send-finish-message");
 
                     int maxTasks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.maxTasks");
@@ -33,7 +33,7 @@ public class ChunkEvent implements Listener{
                         }
                         Block b = e.getChunk().getBlock(8, 64, 8);
 
-                        RandomBlocks rb = new RandomBlocks(x, y, z, blocks, floating_blocks, avoid_near_water, b.getLocation(), send_finish_message);
+                        RandomBlocks rb = new RandomBlocks(x, y, z, blocks, floating_blocks, avoid_water, b.getLocation(), send_finish_message);
                         rb.generatePackets();
                     }
                 }

--- a/src/main/java/me/i2000c/newalb/listeners/ChunkEvent.java
+++ b/src/main/java/me/i2000c/newalb/listeners/ChunkEvent.java
@@ -15,24 +15,27 @@ public class ChunkEvent implements Listener{
     private void onChunkCreated(ChunkPopulateEvent e){
         if(ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.enable")){
             if(WorldManager.isEnabled(e.getWorld().getName())){
-                int x = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.radx");
-                int y = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.rady");
-                int z = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.radz");
-                int blocks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.blocks");
-                boolean floating_blocks = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.floating-blocks");
-                boolean send_finish_message = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.send-finish-message");
-                
-                int maxTasks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.maxTasks");
-                
-                if(RandomBlocks.numTasks < maxTasks){
-                    if(!e.getChunk().isLoaded()){
-                        e.getChunk().load(true);
+                double chance = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.chance") / 100.0;
+                if(Math.random() < chance) {
+                    int x = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.radx");
+                    int y = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.rady");
+                    int z = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.radz");
+                    int blocks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.blocks");
+                    boolean floating_blocks = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.floating-blocks");
+                    boolean send_finish_message = ConfigManager.getMainConfig().getBoolean("GenerateRandomblocks-OnChunkCreated.send-finish-message");
+
+                    int maxTasks = ConfigManager.getMainConfig().getInt("GenerateRandomblocks-OnChunkCreated.maxTasks");
+
+                    if(RandomBlocks.numTasks < maxTasks){
+                        if(!e.getChunk().isLoaded()){
+                            e.getChunk().load(true);
+                        }
+                        Block b = e.getChunk().getBlock(8, 64, 8);
+
+                        RandomBlocks rb = new RandomBlocks(x, y, z, blocks, floating_blocks, b.getLocation(), send_finish_message);
+                        rb.generatePackets();
                     }
-                    Block b = e.getChunk().getBlock(8, 64, 8);
-                    
-                    RandomBlocks rb = new RandomBlocks(x, y, z, blocks, floating_blocks, b.getLocation(), send_finish_message);
-                    rb.generatePackets();
-                }                
+                }
             }
         }
     }

--- a/src/main/java/me/i2000c/newalb/utils/RandomBlocks.java
+++ b/src/main/java/me/i2000c/newalb/utils/RandomBlocks.java
@@ -25,7 +25,7 @@ public class RandomBlocks {
     int radz;
     int blocks;
     boolean floating_blocks;
-    boolean avoid_near_water;
+    boolean avoid_water;
     boolean forceMode;
     private final NewAmazingLuckyBlocks plugin = NewAmazingLuckyBlocks.getInstance();
     private final Player player;
@@ -57,13 +57,13 @@ public class RandomBlocks {
         this.send_finish_message = true;
     }
     
-    public RandomBlocks(int radx, int rady, int radz, int blocks, boolean floating_blocks, boolean avoid_near_water, Location targetLocation, boolean send_finish_message){
+    public RandomBlocks(int radx, int rady, int radz, int blocks, boolean floating_blocks, boolean avoid_water, Location targetLocation, boolean send_finish_message){
         this.radx = radx;
         this.rady = rady;
         this.radz = radz;
         this.blocks = blocks;
         this.floating_blocks = floating_blocks;
-        this.avoid_near_water = avoid_near_water;
+        this.avoid_water = avoid_water;
         
         
         this.targetLocation = targetLocation;
@@ -307,7 +307,7 @@ public class RandomBlocks {
         
         if(!WorldGuardManager.canBuild(player, block.getLocation())) return;
 
-        if (avoid_near_water && isNextToWater(block)) return;
+        if (avoid_water && isNextToWater(block)) return;
         
         TypeManager.getRandomLuckyBlockType().getItem().placeAt(block);
         blocks_placed++;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -400,7 +400,7 @@ GenerateRandomblocks-OnChunkCreated:
   radz: 8
   blocks: 5
   floating-blocks: false
-  avoid-near-water: false # Avoid block generation next to water (sponge becomes wet_sponge and won't work as a lucky block).
+  avoid-water: false # Avoid block generation next to water (sponge becomes wet_sponge and won't work as a lucky block).
   send-finish-message: false
   maxTasks: 5
   chance: 100

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -402,3 +402,4 @@ GenerateRandomblocks-OnChunkCreated:
   floating-blocks: false
   send-finish-message: false
   maxTasks: 5
+  chance: 100

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -400,6 +400,7 @@ GenerateRandomblocks-OnChunkCreated:
   radz: 8
   blocks: 5
   floating-blocks: false
+  avoid-near-water: false
   send-finish-message: false
   maxTasks: 5
   chance: 100

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -400,7 +400,7 @@ GenerateRandomblocks-OnChunkCreated:
   radz: 8
   blocks: 5
   floating-blocks: false
-  avoid-near-water: false
+  avoid-near-water: false # Avoid block generation next to water (sponge becomes wet_sponge and won't work as a lucky block).
   send-finish-message: false
   maxTasks: 5
   chance: 100


### PR DESCRIPTION
This PR adds two new config options to make block generation on chunk load more customizable

`chance` - lets you control how likely it is for random blocks to generate when a new chunk is created (for example, set to 50 for a 50% chance).

`avoid-near-water` - prevents blocks from being generated next to water. This helps avoid issues like sponges turning into wet sponges, which don’t work as lucky blocks.